### PR TITLE
fix: desktop: do not mark rtlLocales array as const

### DIFF
--- a/.github/workflows/check_for_crowdin_updates.yml
+++ b/.github/workflows/check_for_crowdin_updates.yml
@@ -59,6 +59,7 @@ jobs:
             "${{ github.workspace }}/android/session-android/libsession/src/main/java/org/session/libsession/utilities/NonTranslatableStringConstants.kt"
       - name: Prepare Desktop Strings
         run: |
+          rm -rf ${{ github.workspace }}/desktop/_locales/*
           python "${{ github.workspace }}/scripts/crowdin/generate_desktop_strings.py" \
             "${{ github.workspace }}/raw_translations" \
             "${{ github.workspace }}/desktop/_locales" \
@@ -116,8 +117,8 @@ jobs:
         with:
           name: session-android-artifact
           path: |
-            android/app/src/main/res/values*/strings.xml
-            android/session-android/libsession/src/main/java/org/session/libsession/utilities/NonTranslatableStringConstants.kt
+            ${{ github.workspace }}/android/app/src/main/res/values*/strings.xml
+            ${{ github.workspace }}/android/session-android/libsession/src/main/java/org/session/libsession/utilities/NonTranslatableStringConstants.kt
           overwrite: true
           if-no-files-found: warn
           retention-days: 7
@@ -126,8 +127,8 @@ jobs:
         with:
           name: session-desktop-artifact
           path: |
-            desktop/_locales/
-            desktop/ts/localization/constants.ts
+            ${{ github.workspace }}/desktop/_locales
+            ${{ github.workspace }}/desktop/ts/localization/constants.ts
           overwrite: true
           if-no-files-found: warn
           retention-days: 7
@@ -136,8 +137,8 @@ jobs:
         with:
           name: session-ios-artifact
           path: |
-            ios/Session/Meta/Localizable.xcstrings
-            ios/SessionUtilitiesKit/General/Constants.swift
+            ${{ github.workspace }}/ios/Session/Meta/Localizable.xcstrings
+            ${{ github.workspace }}/ios/SessionUtilitiesKit/General/Constants.swift
           overwrite: true
           if-no-files-found: warn
           retention-days: 7

--- a/crowdin/generate_desktop_strings.py
+++ b/crowdin/generate_desktop_strings.py
@@ -129,7 +129,7 @@ def convert_non_translatable_strings_to_type_script(input_file, output_path, rtl
 
         file.write('}\n')
         file.write('\n')
-        file.write(f"export const rtlLocales = [{joined_rtl_locales}] as const;\n")
+        file.write(f"export const rtlLocales = [{joined_rtl_locales}];\n")
         file.write('\n')
 
 def convert_all_files(input_directory):


### PR DESCRIPTION
as the type breaks once imported and needs a cast to Array<string>